### PR TITLE
Add GitHub fork me ribbon

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,5 +1,7 @@
 <header class="site-header">
 
+  {% include ribbon.html %}
+
   <nav class="navbar navbar-default">
     <div class="container-fluid">
       <!-- Brand and toggle get grouped for better mobile display -->

--- a/_includes/ribbon.html
+++ b/_includes/ribbon.html
@@ -1,0 +1,2 @@
+<!-- From https://github.com/blog/273-github-ribbons -->
+<a href="https://github.com/newhavenio/newhavenio-website"><img style="position: absolute; top: 0; right: 0; border: 0; z-index: 9999;" src="https://camo.githubusercontent.com/a6677b08c955af8400f44c6298f40e7d19cc5b2d/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677261795f3664366436642e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png"></a>


### PR DESCRIPTION
This was requested in the Slack chat. I grabbed the code from [GitHub Ribbons][1] using the same color as the old site.

One caveat was that the z-index was lower then the header nav. So I added the `z-index: 9999` to the style tag.

I didn't want to make this a CSS rule because I was trying to stay as close to the original copy/paste code as I could.

[1]: https://github.com/blog/273-github-ribbons

<img width="456" alt="screen shot 2016-01-25 at 14 13 56" src="https://cloud.githubusercontent.com/assets/70075/12561386/ead8bf96-c36d-11e5-912f-d57a4cdce086.png">
