### PR TITLE
Fix tests in chrome and safari

### DIFF
--- a/js/tests/index.html
+++ b/js/tests/index.html
@@ -33,19 +33,19 @@
     }());
   </script>
 
-  <!-- Test Subjects -->
-  <link rel="import" href="../components/meetup-event-card.html" onload="mocha.importLoaded()">
-  <link rel="import" href="../components/meetup-developer-card.html" onload="mocha.importLoaded()">
-  <link rel="import" href="../components/meetup-events.html" onload="mocha.importLoaded()">
-  <link rel="import" href="../components/meetup-developers.html" onload="mocha.importLoaded()">
-  <link rel="import" href="../components/meetup-paginator.html" onload="mocha.importLoaded()">
-
   <!-- Test Suite -->
   <script src="meetup-event-card-test.js"></script>
   <script src="meetup-developer-card-test.js"></script>
   <script src="meetup-events-test.js"></script>
   <script src="meetup-developers-test.js"></script>
   <script src="meetup-paginator-test.js"></script>
+
+  <!-- Test Subjects -->
+  <link rel="import" href="../components/meetup-event-card.html" onload="mocha.importLoaded()">
+  <link rel="import" href="../components/meetup-developer-card.html" onload="mocha.importLoaded()">
+  <link rel="import" href="../components/meetup-events.html" onload="mocha.importLoaded()">
+  <link rel="import" href="../components/meetup-developers.html" onload="mocha.importLoaded()">
+  <link rel="import" href="../components/meetup-paginator.html" onload="mocha.importLoaded()">
 
 </body>
 </html>

--- a/js/tests/index.html
+++ b/js/tests/index.html
@@ -19,6 +19,16 @@
   <script src="https://cdn.rawgit.com/mochajs/mocha/v2.5.3/mocha.js"></script>
   <script>
     (function () {
+      // NodeLists are quirky and ugly across browsers. Here is a one stop
+      // shop for mapping:
+      mocha.mapNodeList = function mapNodeList(nodeList, callback, ctx) {
+        var result = [];
+        for (var i = 0, len = nodeList.length; i < len; i++) {
+          result.push(callback.call(ctx, nodeList[i], i, nodeList));
+        }
+        return result;
+      };
+
       // We can't run the tests till all imports have loaded.
       var pendingImports = 5;
       mocha.importLoaded = function importLoaded() {

--- a/js/tests/meetup-developer-card-test.js
+++ b/js/tests/meetup-developer-card-test.js
@@ -40,8 +40,8 @@ describe('meetup-developer-card', function () {
   it('links to the developer\'s profile', function () {
     this.subject.data = developerFixture;
     var links = this.subject.querySelectorAll('a');
-    var result = Object.keys(links).map(function (key) {
-      return links[key].getAttribute('href');
+    var result = mocha.mapNodeList(links, function (link) {
+      return link.getAttribute('href');
     });
     expect(result).to.include(developerFixture.link);
   });
@@ -49,8 +49,8 @@ describe('meetup-developer-card', function () {
   it('renders a developer\'s photo', function () {
     this.subject.data = developerFixture;
     var links = this.subject.querySelectorAll('img');
-    var result = Object.keys(links).map(function (key) {
-      return links[key].getAttribute('src');
+    var result = mocha.mapNodeList(links, function (link) {
+      return link.getAttribute('src');
     });
     expect(result).to.include(developerFixture.photo.photo_link);
   });

--- a/js/tests/meetup-event-card-test.js
+++ b/js/tests/meetup-event-card-test.js
@@ -31,8 +31,8 @@ describe('meetup-event-card', function () {
 
   it('links to the event', function () {
     var links = this.subject.querySelectorAll('a');
-    var result = Object.keys(links).map(function (key) {
-      return links[key].getAttribute('href');
+    var result = mocha.mapNodeList(links, function (link) {
+      return link.getAttribute('href');
     });
     expect(result).to.include(eventFixture.event_url);
   });
@@ -57,8 +57,8 @@ describe('meetup-event-card', function () {
   it('links to the venue', function () {
     var expected = Meetup.venueMapUrl(eventFixture.venue);
     var links = this.subject.querySelectorAll('a');
-    var result = Object.keys(links).map(function (key) {
-      return links[key].getAttribute('href');
+    var result = mocha.mapNodeList(links, function (link) {
+      return link.getAttribute('href');
     });
     expect(result).to.include(expected);
   });


### PR DESCRIPTION
Sigh, This is getting ridiculous. The problems seem to be that the folks who wrote the webcomponents polyfill either neglected to mention browser differences or the browsers are being stupid at following specs.

* Chrome blocks on HTML Imports
* Firefox does not

So the fix that worked for Firefox cause chrome to execute mocha.run before the test cases were loaded. (╯°□°）╯︵┻━┻

Also, Safari returns length as an enumerable when Chrome and Firefox do not. Again I got bit by using Vanilla JS and only MDN.

Changing the order fixes it. I swear I've now tested this in

* Firefox
* Chrome
* Safari

Really sorry for the multiple pull requests.