### PR TITLE
Add a call for blog posts and licensing info

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,3 +5,11 @@
 3. Make your additions, with tests if appropriate (e.g. new js behavior and bugfixes would require tests. Content changes or fixes to typos, etc. would not).
 4. Make a pull request
 5. :cake:
+
+## Blog posts
+
+We encourage anyone to write content for the blog. We need topics on all things tech. Please concider submitting posts. :cake: may or may not be offered in appreciation.
+
+## Licensing
+
+All contributions will fall under the MIT license unless expicitly stated otherwise.


### PR DESCRIPTION
This is a placeholder for discussion.

Also the `bower.json` file defaults the current project's license to MIT.
