### PR TITLE
Update webpack.config.js for css-loader bump

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,10 +40,7 @@ module.exports = {
         use: extractSass.extract({
           use: [
             {
-              loader: "css-loader",
-              options: {
-                minimize: true,
-              }
+              loader: "css-loader"
             },
             {
               loader: "sass-loader"


### PR DESCRIPTION
According to this thread the `minimize` option was removed from `css-loader` in packages >=1.0.0.