### PR TITLE
Removes minimize: true from CSS loader webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,7 +42,6 @@ module.exports = {
             {
               loader: "css-loader",
               options: {
-                minimize: true,
               }
             },
             {


### PR DESCRIPTION
Looks like this might solve it?

https://github.com/webpack-contrib/css-loader/issues/863

I haven't tried replicating locally so let's see what CI says.